### PR TITLE
Fix CTest errors during partial builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install pytest + pytest-cmake
         run: python3 -m pip install . pytest==${{ matrix.pytest }}.*
 
-      - name: Build Example
+      - name: Configure Example
         shell: bash
         run: |
           cmake --version
@@ -71,9 +71,17 @@ jobs:
               -D "Boost_ROOT=${{ runner.temp }}" \
               -S ./example \
               -B ./build
-          cmake --build ./build --config Release
 
-      - name: Run Tests
+      - name: Build without Python and Test
+        shell: bash
         working-directory: build
-        run: ctest -VV -C Release
+        run: |
+          cmake --build . --target foo CppTest --config Release
+          ctest -VV -C Release -R "CppTest"
 
+      - name: Build and Test
+        shell: bash
+        working-directory: build
+        run: |
+          cmake --build . --config Release
+          ctest -VV -C Release

--- a/cmake/FindPytest.cmake
+++ b/cmake/FindPytest.cmake
@@ -100,6 +100,7 @@ if (Pytest_FOUND AND NOT TARGET Pytest::Pytest)
             set(_BUNDLE_TESTS $ENV{BUNDLE_PYTHON_TESTS})
         endif()
 
+        set(_include_file "${CMAKE_CURRENT_BINARY_DIR}/${NAME}_include.cmake")
         set(_tests_file "${CMAKE_CURRENT_BINARY_DIR}/${NAME}_tests.cmake")
 
         add_custom_target(
@@ -120,9 +121,17 @@ if (Pytest_FOUND AND NOT TARGET Pytest::Pytest)
             -D "CTEST_FILE=${_tests_file}"
             -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/PytestAddTests.cmake")
 
+          file(WRITE "${_include_file}"
+              "if(EXISTS \"${_tests_file}\")\n"
+              "    include(\"${_tests_file}\")\n"
+              "else()\n"
+              "    add_test(${NAME}_NOT_BUILT ${NAME}_NOT_BUILT)\n"
+              "endif()\n"
+          )
+
         # Add discovered tests to directory TEST_INCLUDE_FILES
         set_property(DIRECTORY
-            APPEND PROPERTY TEST_INCLUDE_FILES "${_tests_file}")
+            APPEND PROPERTY TEST_INCLUDE_FILES "${_include_file}")
 
     endfunction()
 

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,6 +4,15 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: changed
+
+        Improved the :func:`pytest_discover_tests` function to use an
+        intermediate CMake script during :term:`CTest` runs. This update
+        enables partial builds that exclude the corresponding CMake target
+        to be executed and tested.
+
 .. release:: 0.7.0
     :date: 2024-05-31
 

--- a/example/test/CMakeLists.txt
+++ b/example/test/CMakeLists.txt
@@ -11,3 +11,28 @@ pytest_discover_tests(
         "DEFAULT_LANGUAGE=en"
         "FOO_SETTINGS_FILE=${CMAKE_CURRENT_SOURCE_DIR}/resource/foo.txt"
 )
+
+if (WIN32)
+    # Expand functions to copy dependent DLLs in the same folder after
+    # building target to ensure that tests can run properly on Windows.
+    macro(add_test NAME)
+        add_custom_command(
+            TARGET ${NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND}
+            -E copy_if_different
+            $<TARGET_RUNTIME_DLLS:${NAME}>
+            $<TARGET_FILE_DIR:${NAME}>
+            COMMAND_EXPAND_LISTS
+        )
+        _add_test(${NAME} ${ARGV})
+    endmacro()
+endif()
+
+add_executable(CppTest fooTest.cpp)
+target_link_libraries(CppTest foo)
+add_test(CppTest CppTest)
+set_tests_properties(
+    CppTest
+    PROPERTIES ENVIRONMENT
+        "FOO_SETTINGS_FILE=${CMAKE_CURRENT_SOURCE_DIR}/resource/foo.txt"
+)

--- a/example/test/fooTest.cpp
+++ b/example/test/fooTest.cpp
@@ -1,0 +1,6 @@
+#include "foo.h"
+
+int main() {
+    Foo foo;
+    return foo.sayHello("en") == "hello" ? 0 : 1;
+}


### PR DESCRIPTION
Modified the inclusion logic to ensure CTest runs tests correctly, even when only part of the codebase is built.