### PR TITLE
Quote pytest path variable in 'add_test' command.

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -2,7 +2,8 @@ name: docs-deploy
 
 on:
   push:
-    branches: [ main ]
+    tags:
+      - "*"
 
 permissions:
   contents: read

--- a/cmake/PytestAddTests.cmake
+++ b/cmake/PytestAddTests.cmake
@@ -22,7 +22,7 @@ if(CMAKE_SCRIPT_MODE_FILE)
         string(APPEND _content
             "add_test(\n"
             "    \"${TEST_GROUP_NAME}\"\n"
-            "    ${PYTEST_EXECUTABLE} \"${WORKING_DIRECTORY}\"\n"
+            "    \"${PYTEST_EXECUTABLE}\" \"${WORKING_DIRECTORY}\"\n"
             ")\n"
             "set_tests_properties(\n"
             "     \"${TEST_GROUP_NAME}\" PROPERTIES\n"
@@ -104,7 +104,7 @@ if(CMAKE_SCRIPT_MODE_FILE)
             string(APPEND _content
                 "add_test(\n"
                 "    \"${test_name}\"\n"
-                "    ${PYTEST_EXECUTABLE} \"${test_case}\"\n"
+                "    \"${PYTEST_EXECUTABLE}\" \"${test_case}\"\n"
                 ")\n"
                 "set_tests_properties(\n"
                 "     \"${test_name}\" PROPERTIES\n"

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,6 +4,14 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: fixed
+
+        Ensure that the 'PYTEST_EXECUTABLE' variable is correctly serialized
+        when the tests are created to handle cases where the path might
+        contain spaces or special characters.
+
 .. release:: 0.8.0
     :date: 2024-08-01
 


### PR DESCRIPTION
Ensure that the 'PYTEST_EXECUTABLE' variable is correctly serialized when the tests are created to handle cases where the path might contain spaces or special characters.