### PR TITLE
Don't use square brackets in test names for parametrized tests

### DIFF
--- a/cmake/PytestAddTests.cmake
+++ b/cmake/PytestAddTests.cmake
@@ -97,6 +97,9 @@ if(CMAKE_SCRIPT_MODE_FILE)
                 set(test_name "${_func}")
             endif()
 
+            string(REPLACE "[" "." test_name "${test_name}")
+            string(REPLACE "]" "" test_name "${test_name}")
+
             set(test_name "${TEST_GROUP_NAME}.${test_name}")
             set(test_case "${WORKING_DIRECTORY}/${line}")
 


### PR DESCRIPTION
When using parametrized tests such as the following:

```python
@pytest.mark.parametrize('a,b', ((1,2), (3,4)))
def test_foo(a, b):
    ...
```

this results in the following tests:
```
    Start 1: PythonTest.test_foo[1-2]
1/2 Test #1: PythonTest.test_foo[1-2] ...........   Passed    0.47 sec
    Start 2: PythonTest.test_foo[3-4]
2/2 Test #2: PythonTest.test_foo[3-4] ...........   Passed    0.47 sec
```

These test names are awkward, as to use them ctest's -R option you need to escape the square brackets to make it valid regex, e.g:
```
ctest -R "PythonTest.test_foo\[1-2\]"
```

This patch changes the test naming to the following form:
```
    Start 1: PythonTest.test_foo.1-2
1/2 Test #1: PythonTest.test_foo.1-2 ...........   Passed    0.47 sec
    Start 2: PythonTest.test_foo.3-4
2/2 Test #2: PythonTest.test_foo.3-4 ...........   Passed    0.47 sec
```
which then works well with the -R option without needing escape characters.

This is important to me as, if there is a failing test, I like to be able to quickly copy paste the test name in the terminal to run just that test for debugging.