### PR TITLE
Do not use environment variables when empty

### DIFF
--- a/cmake/FindPytest.cmake
+++ b/cmake/FindPytest.cmake
@@ -71,8 +71,16 @@ if (Pytest_FOUND AND NOT TARGET Pytest::Pytest)
         endif()
 
         # Convert paths to CMake-friendly format.
-        cmake_path(CONVERT "$ENV{${LIBRARY_ENV_NAME}}" TO_CMAKE_PATH_LIST LIBRARY_PATH)
-        cmake_path(CONVERT "$ENV{PYTHONPATH}" TO_CMAKE_PATH_LIST PYTHON_PATH)
+        if(DEFINED ENV{${LIBRARY_ENV_NAME}})
+            cmake_path(CONVERT "$ENV{${LIBRARY_ENV_NAME}}" TO_CMAKE_PATH_LIST LIBRARY_PATH)
+        else()
+            set(LIBRARY_PATH "")
+        endif()
+        if(DEFINED ENV{PYTHONPATH})
+            cmake_path(CONVERT "$ENV{PYTHONPATH}" TO_CMAKE_PATH_LIST PYTHON_PATH)
+        else()
+            set(PYTHON_PATH "")
+        endif()
 
         # Prepend specified paths to the library and Python paths.
         if (_LIBRARY_PATH_PREPEND)

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,6 +4,16 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: fixed
+
+        Updated scripts to prevent uninitialized variable errors when using `-Werror=dev
+        <https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-Werror>`_
+        and `--warn-uninitialized
+        <https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-warn-uninitialized>`_
+        options. Thanks :github_user:`corrodedHash`!
+
 .. release:: 0.11.3
     :date: 2025-01-19
 


### PR DESCRIPTION
Hello,
thank you for making this!
Worked almost flawlessly, but CMake had one error:
```
CMake Error (dev) at cmake/FindPytest.cmake:74 (cmake_path):
  uninitialized variable 'LD_LIBRARY_PATH'
Call Stack (most recent call first):
  test/CMakeLists.txt:3 (pytest_discover_tests)
This error is for project developers. Use -Wno-error=dev to suppress it.

CMake Error (dev) at cmake/FindPytest.cmake:75 (cmake_path):
  uninitialized variable 'PYTHONPATH'
Call Stack (most recent call first):
  test/CMakeLists.txt:3 (pytest_discover_tests)
This error is for project developers. Use -Wno-error=dev to suppress it.
```

It seemed unhappy when the environment variables were not defined.
I am uncertain if I am using it wrong, or maybe this check is only done in newer versions of CMake, I made a little change to only convert the paths if the environment variables are not empty.