### PR TITLE
Escape arguments to macro call 'create_test'

### DIFF
--- a/cmake/PytestAddTests.cmake
+++ b/cmake/PytestAddTests.cmake
@@ -29,7 +29,7 @@ if(CMAKE_SCRIPT_MODE_FILE)
     # Macro to create individual tests with optional test properties.
     macro(create_test NAME IDENTIFIER)
         string(APPEND _content
-            "add_test(\"${NAME}\" \"${PYTEST_EXECUTABLE}\" \"${IDENTIFIER}\")\n"
+            "add_test([==[${NAME}]==] \"${PYTEST_EXECUTABLE}\" [==[${IDENTIFIER}]==])\n"
         )
 
         # Prepare the properties for the test, including the environment settings.
@@ -45,12 +45,12 @@ if(CMAKE_SCRIPT_MODE_FILE)
         endforeach()
 
         # Append the test properties to the content.
-        string(APPEND _content "set_tests_properties(\"${NAME}\" ${args})\n")
+        string(APPEND _content "set_tests_properties([==[${NAME}]==] ${args})\n")
     endmacro()
 
     # If tests are bundled together, create a single test group.
     if (BUNDLE_TESTS)
-        create_test("${TEST_GROUP_NAME}" "${WORKING_DIRECTORY}")
+        create_test("\${TEST_GROUP_NAME}" "\${WORKING_DIRECTORY}")
 
     else()
         # Set environment variables for collecting tests.
@@ -133,7 +133,7 @@ if(CMAKE_SCRIPT_MODE_FILE)
             set(test_case "${WORKING_DIRECTORY}/${line}")
 
             # Create the test for CTest.
-            create_test("${test_name}" "${test_case}")
+            create_test("\${test_name}" "\${test_case}")
         endforeach()
 
         # Warn if no tests were discovered.

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,6 +4,13 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: fixed
+
+        Updated the :func:`pytest_discover_tests` function to support special
+        characters in test names and identifiers. Thanks :github_user:`corrodedHash`!
+
 .. release:: 0.11.1
     :date: 2024-10-27
 

--- a/test/01-modify-name/CMakeLists.txt
+++ b/test/01-modify-name/CMakeLists.txt
@@ -22,6 +22,7 @@ set(EXPECTED
     "TestModifyName.Simple.test_addition_with_params[5-5-10]"
     "TestModifyName.Simple.test_addition_with_params[10-5-15]"
     "TestModifyName.Simple.test_addition_with_params[0-0-0]"
+    "TestModifyName.Simple.test_byte_char_conversion[\\x17]"
 )
 add_test(NAME TestModifyName.Validate.Simple
     COMMAND ${CMAKE_COMMAND}
@@ -57,6 +58,7 @@ set(EXPECTED
     "TestModifyName.TrimFromName.addition_with_params[5-5-10]"
     "TestModifyName.TrimFromName.addition_with_params[10-5-15]"
     "TestModifyName.TrimFromName.addition_with_params[0-0-0]"
+    "TestModifyName.TrimFromName.byte_char_conversion[\\x17]"
 )
 add_test(NAME TestModifyName.Validate.TrimFromName
     COMMAND ${CMAKE_COMMAND}
@@ -84,6 +86,7 @@ set(EXPECTED
     "TestModifyName.StripParamBrackets.test_addition_with_params.5-5-10"
     "TestModifyName.StripParamBrackets.test_addition_with_params.10-5-15"
     "TestModifyName.StripParamBrackets.test_addition_with_params.0-0-0"
+    "TestModifyName.StripParamBrackets.test_byte_char_conversion.\\x17"
 )
 add_test(NAME TestModifyName.Validate.StripParamBrackets
     COMMAND ${CMAKE_COMMAND}
@@ -111,6 +114,7 @@ set(EXPECTED
     "TestModifyName.IncludeFilePath.test_math_operations.test_addition_with_params[5-5-10]"
     "TestModifyName.IncludeFilePath.test_math_operations.test_addition_with_params[10-5-15]"
     "TestModifyName.IncludeFilePath.test_math_operations.test_addition_with_params[0-0-0]"
+    "TestModifyName.IncludeFilePath.test_math_operations.test_byte_char_conversion[\\x17]"
 )
 add_test(NAME TestModifyName.Validate.IncludeFilePath
     COMMAND ${CMAKE_COMMAND}
@@ -139,6 +143,7 @@ set(EXPECTED
     "TestModifyName.TrimFromFullName.operations.addition_with_params[5-5-10]"
     "TestModifyName.TrimFromFullName.operations.addition_with_params[10-5-15]"
     "TestModifyName.TrimFromFullName.operations.addition_with_params[0-0-0]"
+    "TestModifyName.TrimFromFullName.operations.byte_char_conversion[\\x17]"
 )
 add_test(NAME TestModifyName.Validate.TrimFromFullName
     COMMAND ${CMAKE_COMMAND}

--- a/test/01-modify-name/test_math_operations.py
+++ b/test/01-modify-name/test_math_operations.py
@@ -13,3 +13,9 @@ def test_subtraction():
 ])
 def test_addition_with_params(a, b, expected):
     assert a + b == expected
+
+@pytest.mark.parametrize("input", [
+    "\x17",
+])
+def test_byte_char_conversion(input):
+    assert ord(input) < 128


### PR DESCRIPTION
Pytest does not convert escape characters in strings of parameterized tests

In CMake, if those escape characters then get converted, the test names are not found anymore.

Thus, escape the variables carefully when handling them during the test creation.