### PR TITLE
build and publish a wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build package
         run: |
-          python -m build --sdist
+          python -m build
 
       - name: Check metadata
         run: twine check dist/*
@@ -60,4 +60,3 @@ jobs:
         with:
           name: "v${{ steps.get_version.outputs.version }}"
           body: "Notes: https://python-cmake.github.io/pytest-cmake/release/release_notes.html"
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           cmake -S ./test -B ./test/build
           cmake --build ./test/build
+          ctest --test-dir ./test/build -VV -C Release
 
       - name: Configure Example
         shell: bash

--- a/build_config.py
+++ b/build_config.py
@@ -1,7 +1,6 @@
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 import pathlib
-import subprocess
 
 
 class BuildConfig(BuildHookInterface):
@@ -9,7 +8,6 @@ class BuildConfig(BuildHookInterface):
 
     def initialize(self, version, build_data):
         """Execute builder."""
-        import pytest
 
         root = pathlib.Path(__file__).parent.resolve()
         build_path = (root / "build")
@@ -25,18 +23,10 @@ class BuildConfig(BuildHookInterface):
                 "include(${CMAKE_CURRENT_LIST_DIR}/FindPytest.cmake)\n"
             )
 
-        # Generate CMake config version file for client to target a specific
-        # version of Pytest within CMake projects.
-        version_config_path = (build_path / "PytestConfigVersion.cmake")
-        script_path = (build_path / "PytestConfigVersionScript.cmake")
-        with script_path.open("w", encoding="utf-8") as stream:
+        # Always accept; actual version checks are handled by FindPytest.cmake
+        config_path = (build_path / "PytestConfigVersion.cmake")
+        with config_path.open("w", encoding="utf-8") as stream:
             stream.write(
-                "include(CMakePackageConfigHelpers)\n"
-                "write_basic_package_version_file(\n"
-                f"    \"{str(version_config_path.as_posix())}\"\n"
-                f"    VERSION {pytest.__version__}\n"
-                "    COMPATIBILITY AnyNewerVersion\n"
-                ")"
+                "set(PACKAGE_VERSION_COMPATIBLE TRUE)\n"
+                "set(PACKAGE_VERSION_EXACT TRUE)\n"
             )
-
-        subprocess.call(["cmake", "-P", str(script_path), "-VV"])

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -61,19 +61,3 @@ View the result in your browser at::
 
     file:///path/to/sphinx-build/build/doc/html/index.html
 
-.. _installing/deployment:
-
-Package Deployment
-==================
-
-This package is deployed as a source on `PyPi <https://pypi.org/project/pytest-cmake/>`_
-to allow dynamic adaptation of :term:`CMake` scripts based on the version of :term:`Pytest`
-available at installation. Packaging it as a
-`wheel <https://packaging.python.org/en/latest/specifications/binary-distribution-format>`_
-would lock the :term:`Pytest` version detected during the packaging and deployment process,
-reducing flexibility and compatibility with future versions.
-
-If you wish to deploy the package as a source within a custom index, it is important to include
-the build requirements in your environment (e.g. "hatchling" and "cmake").
-
-.. seealso:: `Package Formats <https://packaging.python.org/en/latest/discussions/package-formats>`_

--- a/doc/release/release_notes.rst
+++ b/doc/release/release_notes.rst
@@ -4,6 +4,18 @@
 Release Notes
 *************
 
+.. release:: Upcoming
+
+    .. change:: changed
+
+        Updated :term:`CMake` packaging by simplifying
+        `PytestConfigVersion.cmake` so that version compatibility is no longer
+        fixed at build time. Version discovery and validation are handled
+        dynamically by `FindPytest.cmake`, with `PytestConfig.cmake` serving
+        only as a thin entry point for :term:`CMake` package discovery.
+        Wheel distribution is fully supported and recommended.
+        Thanks :github_user:`dimbleby`!
+
 .. release:: 1.2.0
     :date: 2025-12-08
 
@@ -165,7 +177,7 @@ Release Notes
 
     .. change:: changed
 
-        Added documentation for :ref:`installing/deployment`.
+        Added documentation for deployment.
 
     .. change:: changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.scripts]

--- a/test/00-version-fails/CMakeLists.txt
+++ b/test/00-version-fails/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(TestVersionFails)
+
+find_package(Pytest 99.0 REQUIRED)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,16 @@ cmake_minimum_required(VERSION 3.20)
 
 project(Test)
 
+enable_testing()
 include(ExternalProject)
+
+add_test(
+    NAME TestVersionFails
+    COMMAND ${CMAKE_COMMAND}
+    -S ${CMAKE_CURRENT_SOURCE_DIR}/tests/00-version-fails
+    -B ${CMAKE_BINARY_DIR}/_deps/00-version-fails
+)
+set_tests_properties(TestVersionFails PROPERTIES WILL_FAIL TRUE)
 
 ExternalProject_Add(
     TestModifyName


### PR DESCRIPTION
All installation in python is from wheel: so if maintainers do not publish wheels then every user install must begin by building one.

That has a few (minor) disadvantages: it is slower, it is a thing that can go wrong.  Security-conscious users will not want to run arbitrary code at install time.

Therefore best practice - even for pure python projects - is to publish both sdist and also wheel.